### PR TITLE
Auto-attach cycles to IC calls using cost primitives

### DIFF
--- a/.github/workflows/mops-test.yml
+++ b/.github/workflows/mops-test.yml
@@ -16,8 +16,6 @@ jobs:
         with:
           node-version: 20
       - uses: ZenVoich/setup-mops@v1
-        with:
-          mops-version: 1.7.2-pre.0
 
       - name: Install dfx
         uses: dfinity/setup-dfx@main

--- a/.github/workflows/mops-test.yml
+++ b/.github/workflows/mops-test.yml
@@ -3,7 +3,6 @@ name: mops test
 on:
   push:
     branches:
-      - main
       - master
   pull_request:
 

--- a/.github/workflows/mops-test.yml
+++ b/.github/workflows/mops-test.yml
@@ -16,6 +16,8 @@ jobs:
         with:
           node-version: 20
       - uses: ZenVoich/setup-mops@v1
+        with:
+          mops-version: 1.7.2-pre.0
 
       - name: Install dfx
         uses: dfinity/setup-dfx@main

--- a/.github/workflows/mops-test.yml
+++ b/.github/workflows/mops-test.yml
@@ -18,6 +18,11 @@ jobs:
           node-version: 20
       - uses: ZenVoich/setup-mops@v1
 
+      - name: Install dfx
+        uses: dfinity/setup-dfx@main
+      - name: Confirm successful installation
+        run: dfx --version
+
       - name: install mops packages
         run: mops install
 

--- a/.github/workflows/mops-test.yml
+++ b/.github/workflows/mops-test.yml
@@ -1,0 +1,25 @@
+name: mops test
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: ZenVoich/setup-mops@v1
+
+      - name: install mops packages
+        run: mops install
+
+      - name: run tests
+        run: mops test

--- a/mops.toml
+++ b/mops.toml
@@ -3,8 +3,17 @@ name = "ic"
 version = "2.0.0"
 description = "IC management canister interface (aaaaa-aa)"
 repository = "https://github.com/ZenVoich/ic"
-keywords = [ "ic", "types", "interface" ]
+keywords = [ "ic", "types", "interface", "http" ]
 license = "MIT"
 
-[toolchain]
+[dependencies]
+base = "0.14.10"
+
+[requirements]
 moc = "0.14.10"
+
+[toolchain]
+moc = "0.14.11"
+
+[dev-dependencies]
+test = "2.1.1"

--- a/mops.toml
+++ b/mops.toml
@@ -5,3 +5,6 @@ description = "IC management canister interface (aaaaa-aa)"
 repository = "https://github.com/ZenVoich/ic"
 keywords = [ "ic", "types", "interface" ]
 license = "MIT"
+
+[toolchain]
+moc = "0.14.10"

--- a/src/Call.mo
+++ b/src/Call.mo
@@ -4,24 +4,25 @@ import Prim "mo:prim";
 
 import IC "lib";
 
-/// Provides wrapper functions for calls to the IC management canister that:
-///
-/// 1. Calculate cycles needed for the call and automatically add them to the call.
-///    Only minimal amount of cycles are added to the call. This helps the canister to make more calls in parallel without running out of cycles.
-///
-/// 2. Report errors before making the call.
-///    Functions with a `try` prefix perform extra validation before making the call and return the error if it is not possible to make the call.
+/// Provides wrapper functions for calls to the IC management canister that
+/// calculate cycles needed for the call and automatically add them to the call.
+/// Only minimal amount of cycles are added to the call. This helps the canister to make more calls in parallel without running out of cycles.
 ///
 /// Cost calculation functions are in the `Cost` submodule.
 module {
+  /// Invokes the `create_canister` method of the IC management canister and automatically adds the necessary cycles to the call.
   public func createCanister(args : IC.CreateCanisterArgs) : async IC.CreateCanisterResult {
     await (with cycles = Cost.createCanister()) IC.ic.create_canister(args);
   };
 
+  /// Invokes the `http_request` method of the IC management canister and automatically adds the necessary cycles to the call.
   public func httpRequest(args : IC.HttpRequestArgs) : async IC.HttpRequestResult {
     await (with cycles = Cost.httpRequest(args)) IC.ic.http_request(args);
   };
 
+  /// Invokes the `sign_with_ecdsa` method of the IC management canister and automatically adds the necessary cycles to the call.
+  ///
+  /// Returns an error if the arguments are invalid and the cost cannot be determined.
   public func trySignWithEcdsa(args : IC.SignWithEcdsaArgs) : async Result<IC.SignWithEcdsaResult, SignError> {
     let { name; curve } = args.key_id;
     switch (Cost.signWithEcdsa(name, curve)) {
@@ -30,6 +31,20 @@ module {
     };
   };
 
+  /// Invokes the `sign_with_ecdsa` method of the IC management canister and automatically adds the necessary cycles to the call.
+  ///
+  /// Traps if the arguments are invalid and the cost cannot be determined.
+  public func signWithEcdsa(args : IC.SignWithEcdsaArgs) : async IC.SignWithEcdsaResult {
+    let { name; curve } = args.key_id;
+    switch (Cost.signWithEcdsa(name, curve)) {
+      case (#ok(cycles)) await (with cycles) IC.ic.sign_with_ecdsa(args);
+      case (#err(error)) Debug.trap("Cannot determine cost of sign_with_ecdsa: " # debug_show (error));
+    };
+  };
+
+  /// Invokes the `sign_with_schnorr` method of the IC management canister and automatically adds the necessary cycles to the call.
+  ///
+  /// Returns an error if the arguments are invalid and the cost cannot be determined.
   public func trySignWithSchnorr(args : IC.SignWithSchnorrArgs) : async Result<IC.SignWithSchnorrResult, SignError> {
     let { name; algorithm } = args.key_id;
     switch (Cost.signWithSchnorr(name, algorithm)) {
@@ -38,10 +53,21 @@ module {
     };
   };
 
+  /// Invokes the `sign_with_schnorr` method of the IC management canister and automatically adds the necessary cycles to the call.
+  ///
+  /// Traps if the arguments are invalid and the cost cannot be determined.
+  public func signWithSchnorr(args : IC.SignWithSchnorrArgs) : async IC.SignWithSchnorrResult {
+    let { name; algorithm } = args.key_id;
+    switch (Cost.signWithSchnorr(name, algorithm)) {
+      case (#ok(cycles)) await (with cycles) IC.ic.sign_with_schnorr(args);
+      case (#err(error)) Debug.trap("Cannot determine cost of sign_with_schnorr: " # debug_show (error));
+    };
+  };
+
   /// Cycle cost calculation functions.
   /// Refer to the [IC Interface Specification: section Cycle cost calculation](https://internetcomputer.org/docs/references/ic-interface-spec#system-api-cycle-cost) for more information.
   public module Cost {
-    // TODO: How this is meant to be used? Improve the API depending on the usecase, Nat64 arguments are not ideal
+    // Future work: How this is meant to be used? Improve the API depending on the usecase, Nat64 arguments are not ideal
     public func call(methodNameSize : Nat64, payloadSize : Nat64) : Nat = Prim.costCall(methodNameSize, payloadSize);
 
     public func createCanister() : Nat = Prim.costCreateCanister();
@@ -64,7 +90,7 @@ module {
       let (code, cyclesOrArbitrary) = Prim.costSignWithEcdsa(keyName, curveEncoding);
       switch (code) {
         case 0 #ok(cyclesOrArbitrary);
-        case 1 Debug.trap("Unexpected error: Invalid ecdsa curve encoding.");
+        case 1 Debug.trap("Unreachable: Invalid ecdsa curve encoding.");
         case 2 #err(#invalidKeyName);
         case _ Debug.trap("Invalid error code returned from Prim.costSignWithEcdsa");
       };
@@ -78,7 +104,7 @@ module {
       let (code, cyclesOrArbitrary) = Prim.costSignWithSchnorr(keyName, algorithmEncoding);
       switch (code) {
         case 0 #ok(cyclesOrArbitrary);
-        case 1 Debug.trap("Unexpected error: Invalid schnorr algorithm encoding.");
+        case 1 Debug.trap("Unreachable: Invalid schnorr algorithm encoding.");
         case 2 #err(#invalidKeyName);
         case _ Debug.trap("Invalid error code returned from Prim.costSignWithSchnorr");
       };
@@ -106,8 +132,9 @@ module {
       switch (request.transform) {
         case (?transform) {
           size += Prim.natToNat64(transform.context.size());
-          // TODO: How to get the method name length otherwise?
-          // This gets us both the method name and the actor
+          // Future work: How to get the method name length otherwise?
+          // This gets us both the method name and the actor.
+          // It results in a few extra cycles (cannot be exact now) but it's a good approximation.
           let blob = to_candid (transform.function);
           size += Prim.natToNat64(blob.size());
         };

--- a/src/Call.mo
+++ b/src/Call.mo
@@ -1,54 +1,125 @@
+import Debug "mo:base/Debug";
+import Result "mo:base/Result";
 import Prim "mo:prim";
 
 import IC "lib";
 
+/// Provides wrapper functions for calls to the IC management canister that:
+///
+/// 1. Calculate cycles needed for the call and automatically add them to the call.
+///    Only minimal amount of cycles are added to the call. This helps the canister to make more calls in parallel without running out of cycles.
+///
+/// 2. Report errors before making the call.
+///    Functions with a `try` prefix perform extra validation before making the call and return the error if it is not possible to make the call.
+///
+/// Cost calculation functions are in the `Cost` submodule.
 module {
+  public func createCanister(args : IC.CreateCanisterArgs) : async IC.CreateCanisterResult {
+    await (with cycles = Cost.createCanister()) IC.ic.create_canister(args);
+  };
+
   public func httpRequest(args : IC.HttpRequestArgs) : async IC.HttpRequestResult {
-    let cycles = costHttpRequest(args);
-    await (with cycles) IC.ic.http_request(args);
+    await (with cycles = Cost.httpRequest(args)) IC.ic.http_request(args);
   };
 
-  func costHttpRequest(args : IC.HttpRequestArgs) : Nat {
-    let requestSize = calculateRequestSize(args);
-    let maxResponseBytes : Nat64 = switch (args.max_response_bytes) {
-      // As stated here: https://internetcomputer.org/docs/references/ic-interface-spec#ic-http_request:
-      // "The upper limit on the maximal size for the response is 2MB (2,000,000B) and this value also applies if no maximal size value is specified."
-      case null 2_000_000;
-      case (?bytes) bytes;
+  public func trySignWithEcdsa(args : IC.SignWithEcdsaArgs, keyName : Text, curve : IC.EcdsaCurve) : async Result<IC.SignWithEcdsaResult, SignError> {
+    switch (Cost.signWithEcdsa(keyName, curve)) {
+      case (#ok(cycles)) #ok(await (with cycles) IC.ic.sign_with_ecdsa(args));
+      case (#err(error)) #err(error);
     };
-    Prim.costHttpRequest(requestSize, maxResponseBytes);
   };
 
-  func calculateRequestSize(request : IC.HttpRequestArgs) : Nat64 {
-    var size : Nat64 = 0;
-
-    // Add URL byte length
-    size += Prim.natToNat64(request.url.size());
-
-    // Add headers byte length (sum of all names and values)
-    for (header in request.headers.vals()) {
-      size += Prim.natToNat64(header.name.size());
-      size += Prim.natToNat64(header.value.size());
+  public func trySignWithSchnorr(args : IC.SignWithSchnorrArgs, keyName : Text, algorithm : IC.SchnorrAlgorithm) : async Result<IC.SignWithSchnorrResult, SignError> {
+    switch (Cost.signWithSchnorr(keyName, algorithm)) {
+      case (#ok(cycles)) #ok(await (with cycles) IC.ic.sign_with_schnorr(args));
+      case (#err(error)) #err(error);
     };
+  };
 
-    // Add body length if present
-    switch (request.body) {
-      case (?body) { size += Prim.natToNat64(body.size()) };
-      case null {};
-    };
+  /// Cycle cost calculation functions.
+  /// Refer to the [IC Interface Specification: section Cycle cost calculation](https://internetcomputer.org/docs/references/ic-interface-spec#system-api-cycle-cost) for more information.
+  public module Cost {
+    // TODO: How this is meant to be used? Improve the API depending on the usecase, Nat64 arguments are not ideal
+    public func call(methodNameSize : Nat64, payloadSize : Nat64) : Nat = Prim.costCall(methodNameSize, payloadSize);
 
-    // Add transform context length if present
-    switch (request.transform) {
-      case (?transform) {
-        size += Prim.natToNat64(transform.context.size());
-        // How to get the method name length otherwise?
-        // This gets us both the method name and the actor
-        let blob = to_candid (transform.function);
-        size += Prim.natToNat64(blob.size());
+    public func createCanister() : Nat = Prim.costCreateCanister();
+
+    public func httpRequest(args : IC.HttpRequestArgs) : Nat {
+      let requestSize = calculateRequestSize(args);
+      let maxResponseBytes : Nat64 = switch (args.max_response_bytes) {
+        // As stated here: https://internetcomputer.org/docs/references/ic-interface-spec#ic-http_request:
+        // "The upper limit on the maximal size for the response is 2MB (2,000,000B) and this value also applies if no maximal size value is specified."
+        case null 2_000_000;
+        case (?bytes) bytes;
       };
-      case null {};
+      Prim.costHttpRequest(requestSize, maxResponseBytes);
     };
 
-    size;
+    public func signWithEcdsa(keyName : Text, curve : IC.EcdsaCurve) : Result<Nat, SignError> {
+      let curveEncoding : Nat32 = switch (curve) {
+        case (#secp256k1) 0;
+      };
+      let (code, cyclesOrArbitrary) = Prim.costSignWithEcdsa(keyName, curveEncoding);
+      switch (code) {
+        case 0 #ok(cyclesOrArbitrary);
+        case 1 #err(#invalidCurveOrAlgorithm);
+        case 2 #err(#invalidKeyName);
+        case _ Debug.trap("Invalid error code returned from Prim.costSignWithEcdsa");
+      };
+    };
+
+    public func signWithSchnorr(keyName : Text, algorithm : IC.SchnorrAlgorithm) : Result<Nat, SignError> {
+      let algorithmEncoding : Nat32 = switch (algorithm) {
+        case (#bip340secp256k1) 0;
+        case (#ed25519) 1;
+      };
+      let (code, cyclesOrArbitrary) = Prim.costSignWithSchnorr(keyName, algorithmEncoding);
+      switch (code) {
+        case 0 #ok(cyclesOrArbitrary);
+        case 1 #err(#invalidCurveOrAlgorithm);
+        case 2 #err(#invalidKeyName);
+        case _ Debug.trap("Invalid error code returned from Prim.costSignWithSchnorr");
+      };
+    };
+
+    func calculateRequestSize(request : IC.HttpRequestArgs) : Nat64 {
+      var size : Nat64 = 0;
+
+      // Add URL byte length
+      size += Prim.natToNat64(request.url.size());
+
+      // Add headers byte length (sum of all names and values)
+      for (header in request.headers.vals()) {
+        size += Prim.natToNat64(header.name.size());
+        size += Prim.natToNat64(header.value.size());
+      };
+
+      // Add body length if present
+      switch (request.body) {
+        case (?body) { size += Prim.natToNat64(body.size()) };
+        case null {};
+      };
+
+      // Add transform context length if present
+      switch (request.transform) {
+        case (?transform) {
+          size += Prim.natToNat64(transform.context.size());
+          // TODO: How to get the method name length otherwise?
+          // This gets us both the method name and the actor
+          let blob = to_candid (transform.function);
+          size += Prim.natToNat64(blob.size());
+        };
+        case null {};
+      };
+
+      size;
+    };
   };
+
+  public type SignError = {
+    #invalidCurveOrAlgorithm;
+    #invalidKeyName;
+  };
+
+  type Result<Ok, Err> = Result.Result<Ok, Err>;
 };

--- a/src/Call.mo
+++ b/src/Call.mo
@@ -1,0 +1,54 @@
+import Prim "mo:prim";
+
+import IC "lib";
+
+module {
+  public func httpRequest(args : IC.HttpRequestArgs) : async IC.HttpRequestResult {
+    let cycles = costHttpRequest(args);
+    await (with cycles) IC.ic.http_request(args);
+  };
+
+  func costHttpRequest(args : IC.HttpRequestArgs) : Nat {
+    let requestSize = calculateRequestSize(args);
+    let maxResponseBytes : Nat64 = switch (args.max_response_bytes) {
+      // As stated here: https://internetcomputer.org/docs/references/ic-interface-spec#ic-http_request:
+      // "The upper limit on the maximal size for the response is 2MB (2,000,000B) and this value also applies if no maximal size value is specified."
+      case null 2_000_000;
+      case (?bytes) bytes;
+    };
+    Prim.costHttpRequest(requestSize, maxResponseBytes);
+  };
+
+  func calculateRequestSize(request : IC.HttpRequestArgs) : Nat64 {
+    var size : Nat64 = 0;
+
+    // Add URL byte length
+    size += Prim.natToNat64(request.url.size());
+
+    // Add headers byte length (sum of all names and values)
+    for (header in request.headers.vals()) {
+      size += Prim.natToNat64(header.name.size());
+      size += Prim.natToNat64(header.value.size());
+    };
+
+    // Add body length if present
+    switch (request.body) {
+      case (?body) { size += Prim.natToNat64(body.size()) };
+      case null {};
+    };
+
+    // Add transform context length if present
+    switch (request.transform) {
+      case (?transform) {
+        size += Prim.natToNat64(transform.context.size());
+        // How to get the method name length otherwise?
+        // This gets us both the method name and the actor
+        let blob = to_candid (transform.function);
+        size += Prim.natToNat64(blob.size());
+      };
+      case null {};
+    };
+
+    size;
+  };
+};

--- a/src/Call.mo
+++ b/src/Call.mo
@@ -64,7 +64,7 @@ module {
       let (code, cyclesOrArbitrary) = Prim.costSignWithEcdsa(keyName, curveEncoding);
       switch (code) {
         case 0 #ok(cyclesOrArbitrary);
-        case 1 #err(#invalidCurveOrAlgorithm);
+        case 1 Debug.trap("Unexpected error: Invalid ecdsa curve encoding.");
         case 2 #err(#invalidKeyName);
         case _ Debug.trap("Invalid error code returned from Prim.costSignWithEcdsa");
       };
@@ -78,7 +78,7 @@ module {
       let (code, cyclesOrArbitrary) = Prim.costSignWithSchnorr(keyName, algorithmEncoding);
       switch (code) {
         case 0 #ok(cyclesOrArbitrary);
-        case 1 #err(#invalidCurveOrAlgorithm);
+        case 1 Debug.trap("Unexpected error: Invalid schnorr algorithm encoding.");
         case 2 #err(#invalidKeyName);
         case _ Debug.trap("Invalid error code returned from Prim.costSignWithSchnorr");
       };
@@ -119,7 +119,6 @@ module {
   };
 
   public type SignError = {
-    #invalidCurveOrAlgorithm;
     #invalidKeyName;
   };
 

--- a/src/Call.mo
+++ b/src/Call.mo
@@ -22,15 +22,17 @@ module {
     await (with cycles = Cost.httpRequest(args)) IC.ic.http_request(args);
   };
 
-  public func trySignWithEcdsa(args : IC.SignWithEcdsaArgs, keyName : Text, curve : IC.EcdsaCurve) : async Result<IC.SignWithEcdsaResult, SignError> {
-    switch (Cost.signWithEcdsa(keyName, curve)) {
+  public func trySignWithEcdsa(args : IC.SignWithEcdsaArgs) : async Result<IC.SignWithEcdsaResult, SignError> {
+    let { name; curve } = args.key_id;
+    switch (Cost.signWithEcdsa(name, curve)) {
       case (#ok(cycles)) #ok(await (with cycles) IC.ic.sign_with_ecdsa(args));
       case (#err(error)) #err(error);
     };
   };
 
-  public func trySignWithSchnorr(args : IC.SignWithSchnorrArgs, keyName : Text, algorithm : IC.SchnorrAlgorithm) : async Result<IC.SignWithSchnorrResult, SignError> {
-    switch (Cost.signWithSchnorr(keyName, algorithm)) {
+  public func trySignWithSchnorr(args : IC.SignWithSchnorrArgs) : async Result<IC.SignWithSchnorrResult, SignError> {
+    let { name; algorithm } = args.key_id;
+    switch (Cost.signWithSchnorr(name, algorithm)) {
       case (#ok(cycles)) #ok(await (with cycles) IC.ic.sign_with_schnorr(args));
       case (#err(error)) #err(error);
     };

--- a/test/Call.test.mo
+++ b/test/Call.test.mo
@@ -18,11 +18,11 @@ actor {
       func() : async () {
         let cycles = Call.Cost.createCanister();
         ignore await (with cycles) IC.ic.create_canister(createCanisterArgs);
-        await expectThrows(
+        await expect.call(
           func() : async () {
             ignore await (with cycles = cycles - 1) IC.ic.create_canister(createCanisterArgs);
           }
-        );
+        ).reject();
       },
     );
 
@@ -60,11 +60,11 @@ actor {
   func httpRequestExactCost(request : IC.HttpRequestArgs) : () -> async () = func() : async () {
     let cycles = Call.Cost.httpRequest(request);
     ignore await (with cycles) IC.ic.http_request(request);
-    await expectThrows(
+    await expect.call(
       func() : async () {
         ignore await (with cycles = cycles - 1) IC.ic.http_request(request);
       }
-    );
+    ).reject();
   };
 
   public shared query func transformFunction({
@@ -73,15 +73,6 @@ actor {
   }) : async IC.HttpRequestResult {
     ignore context;
     { response with headers = []; status = 200 };
-  };
-
-  func expectThrows(f : () -> async ()) : async () {
-    expect.bool(
-      try {
-        await f();
-        false;
-      } catch _ true
-    ).isTrue();
   };
 
   let createCanisterArgs : IC.CreateCanisterArgs = {

--- a/test/Call.test.mo
+++ b/test/Call.test.mo
@@ -1,0 +1,107 @@
+import Blob "mo:base/Blob";
+import { suite; test; expect } "mo:test/async";
+
+import IC "../src/lib";
+import Call "../src/Call";
+
+actor {
+  public func runTests() : async () {
+    await test(
+      "createCanister should succeed",
+      func() : async () {
+        ignore await Call.createCanister(createCanisterArgs);
+      },
+    );
+
+    await test(
+      "createCanister cost should be exact",
+      func() : async () {
+        let cycles = Call.Cost.createCanister();
+        ignore await (with cycles) IC.ic.create_canister(createCanisterArgs);
+        await expectThrows(
+          func() : async () {
+            ignore await (with cycles = cycles - 1) IC.ic.create_canister(createCanisterArgs);
+          }
+        );
+      },
+    );
+
+    await test(
+      "httpRequest should succeed",
+      func() : async () {
+        ignore await Call.httpRequest(request);
+        ignore await Call.httpRequest({ request with headers });
+        ignore await Call.httpRequest({ request with body });
+        ignore await Call.httpRequest({ request with max_response_bytes });
+        ignore await Call.httpRequest({
+          request with headers;
+          body;
+          max_response_bytes;
+        });
+        ignore await Call.httpRequest({ request with transform });
+      },
+    );
+
+    await suite(
+      "httpRequest cost should be exact",
+      func() : async () {
+        await test("default", httpRequestExactCost(request));
+        await test("with headers", httpRequestExactCost({ request with headers }));
+        await test("with body", httpRequestExactCost({ request with body }));
+        await test("with max_response_bytes", httpRequestExactCost({ request with max_response_bytes }));
+        await test("with all above", httpRequestExactCost({ request with headers; body; max_response_bytes }));
+
+        // Future work: transform can't be exact yet
+        // await test("with transform", httpRequestExactCost({ request with transform }));
+      },
+    );
+  };
+
+  func httpRequestExactCost(request : IC.HttpRequestArgs) : () -> async () = func() : async () {
+    let cycles = Call.Cost.httpRequest(request);
+    ignore await (with cycles) IC.ic.http_request(request);
+    await expectThrows(
+      func() : async () {
+        ignore await (with cycles = cycles - 1) IC.ic.http_request(request);
+      }
+    );
+  };
+
+  public shared query func transformFunction({
+    context : Blob;
+    response : IC.HttpRequestResult;
+  }) : async IC.HttpRequestResult {
+    ignore context;
+    { response with headers = []; status = 200 };
+  };
+
+  func expectThrows(f : () -> async ()) : async () {
+    expect.bool(
+      try {
+        await f();
+        false;
+      } catch _ true
+    ).isTrue();
+  };
+
+  let createCanisterArgs : IC.CreateCanisterArgs = {
+    settings = null;
+    sender_canister_version = null;
+  };
+
+  let request : IC.HttpRequestArgs = {
+    url = "https://ic0.app";
+    method = #get;
+    headers = [];
+    body = null;
+    max_response_bytes = null;
+    transform = null;
+  };
+  let headers = [{ name = "x-test"; value = "test" }];
+  let body = ?to_candid ([1, 2, 3]);
+  let max_response_bytes : ?Nat64 = ?1_000;
+  let transform = ?{
+    function = transformFunction;
+    context = Blob.fromArray([23, 41, 13, 6, 17]);
+  };
+};

--- a/test/Call.test.mo
+++ b/test/Call.test.mo
@@ -63,6 +63,7 @@ actor {
     await test(
       "trySignWithEcdsa should succeed",
       func() : async () {
+        ignore await Call.signWithEcdsa(ecdsaArgs(caller, #secp256k1, "test_key_1"));
         expectResult(await Call.trySignWithEcdsa(ecdsaArgs(caller, #secp256k1, "test_key_1"))).isOk();
         expectResult(await Call.trySignWithEcdsa(ecdsaArgs(caller, #secp256k1, "wrong key"))).equal(#err(#invalidKeyName));
       },
@@ -85,6 +86,8 @@ actor {
     await test(
       "trySignWithSchnorr should succeed",
       func() : async () {
+        ignore await Call.signWithSchnorr(schnorrArgs(caller, #bip340secp256k1, "test_key_1"));
+        ignore await Call.signWithSchnorr(schnorrArgs(caller, #ed25519, "test_key_1"));
         expectResult(await Call.trySignWithSchnorr(schnorrArgs(caller, #bip340secp256k1, "test_key_1"))).isOk();
         expectResult(await Call.trySignWithSchnorr(schnorrArgs(caller, #ed25519, "test_key_1"))).isOk();
         expectResult(await Call.trySignWithSchnorr(schnorrArgs(caller, #ed25519, "wrong key"))).equal(#err(#invalidKeyName));

--- a/test/Call.test.mo
+++ b/test/Call.test.mo
@@ -2,7 +2,7 @@ import Blob "mo:base/Blob";
 import Principal "mo:base/Principal";
 import Result "mo:base/Result";
 import Debug "mo:base/Debug";
-import { suite; test; expect; fail } "mo:test/async";
+import { suite; test; expect } "mo:test/async";
 import ExpectResult "mo:test/expect/expect-result";
 
 import IC "../src";


### PR DESCRIPTION
This PR is a suggestion to add wrappers for `ic` calls like `http_request` that automatically calculate the minimum amount of cycles and attach them with the call. It would help users avoid to guess how many cycles to add and allow more calls to run in parallel without running out of cycles.

This is possible with the recent (since 0.14.10 moc) addition of cost primitives: `Prim.cost...` functions.

@ZenVoich What do you think of this extra functionality? Would it be a good place for them in this package? 
The current API is just a draft, just trying to show what is possible. I wanted to ask you before working on it further 🙂