### PR TITLE
ci: auto-publish to mops registry on version bump

### DIFF
--- a/.github/workflows/mops-publish.yml
+++ b/.github/workflows/mops-publish.yml
@@ -1,0 +1,105 @@
+name: mops publish
+
+# Publishes to the mops registry when `version` in mops.toml changes on master.
+# Use workflow_dispatch to force a re-publish (e.g. retry after a transient failure).
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: write # tag the release after a successful publish
+
+concurrency:
+  group: mops-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Decide whether to publish
+        id: decide
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          extract() {
+            sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' | head -n1
+          }
+          NEW=$(extract < mops.toml)
+          if [ -z "$NEW" ]; then
+            echo "::error::Could not read version from mops.toml"
+            exit 1
+          fi
+          echo "version=$NEW" >> "$GITHUB_OUTPUT"
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "Forcing publish of v$NEW (workflow_dispatch)"
+            exit 0
+          fi
+
+          # Compare against the tip of master before this push, not HEAD~1, so
+          # a multi-commit push that bumps the version in a non-tip commit is
+          # still detected. New-branch pushes report an all-zeros BEFORE_SHA;
+          # treat that as "publish" since there's no prior version to diff.
+          ZERO_SHA="0000000000000000000000000000000000000000"
+          if [ -z "$BEFORE_SHA" ] || [ "$BEFORE_SHA" = "$ZERO_SHA" ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "No prior commit to compare against; publishing v$NEW"
+            exit 0
+          fi
+
+          OLD=$(git show "$BEFORE_SHA:mops.toml" 2>/dev/null | extract || true)
+          if [ "$NEW" != "$OLD" ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "Version changed: ${OLD:-<none>} -> $NEW"
+          else
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "Version unchanged ($NEW); skipping publish"
+          fi
+
+      - name: Set up dfx
+        if: steps.decide.outputs.publish == 'true'
+        # Pinned action SHA + dfx version, matching mops-test.yml.
+        uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365
+        with:
+          dfx-version: 0.30.1
+
+      - name: Set up mops
+        if: steps.decide.outputs.publish == 'true'
+        uses: dfinity/setup-mops@3e94e453352269b34137b5ce49f09a8df81bed7d # v1.4.1
+        with:
+          identity-pem: ${{ secrets.MOPS_IDENTITY_PEM }}
+
+      - name: Install packages
+        if: steps.decide.outputs.publish == 'true'
+        run: mops install
+
+      - name: Publish
+        if: steps.decide.outputs.publish == 'true'
+        run: mops publish
+
+      - name: Tag release
+        if: steps.decide.outputs.publish == 'true'
+        env:
+          VERSION: ${{ steps.decide.outputs.version }}
+        run: |
+          set -euo pipefail
+          TAG="v$VERSION"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "Tag $TAG already exists; skipping"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "v$VERSION"
+          git push origin "$TAG"


### PR DESCRIPTION
## Why

Releases on this repo are manual: bump `version` in `mops.toml`, then someone has to remember to run `mops publish` locally with the right identity. Easy to forget, easy to publish without bumping (or bump without publishing).

## What changes for maintainers

Bump `version` in `mops.toml`, merge to `master`, done — the registry publish and a `v<version>` git tag happen automatically.

- Publish is gated on an actual version diff against the previous tip of `master`. Pushes that don't touch `version` are no-ops.
- The tag is pushed only after `mops publish` succeeds, so failed publishes don't leave stray tags.
- `workflow_dispatch` is available as a manual retry (e.g. transient registry failure) without needing to bump the version again.
- Concurrency-grouped to prevent two rapid pushes from racing the registry.

Requires the `MOPS_IDENTITY_PEM` repo secret (already configured).

## Notes

- Compares against `github.event.before` rather than `HEAD~1`, so a multi-commit push that bumps the version in a non-tip commit is still detected.
- Uses the default `GITHUB_TOKEN` with `contents: write` for the tag push. A GitHub App token isn't needed because nothing downstream listens for the tag.
- Does **not** gate on `mops-test.yml`. PRs are expected to be tested before merge; adding a `workflow_run` chain was considered and deferred.

## Test plan

- [ ] After merge, click "Run workflow" on `mops publish` to smoke-test the setup. Steps up through `mops install` should pass; `mops publish` will fail with "version already exists" — that's the expected signal.
- [ ] Next real release: bump `version`, merge, verify the registry has the new version and `v<version>` tag exists.

Made with [Cursor](https://cursor.com)