### PR TITLE
fix: update upstream ic.did source to dfinity/developer-docs + add canister_metrics (v4.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
+## 4.1.0
+
+### Additive changes
+
+- New types: `CyclesConsumed`, `CanisterMetricsArgs`, `CanisterMetricsResult`.
+- New method: `canister_metrics` (query) — returns per-category cycles consumed by a canister.
+
+### Housekeeping
+
+- Updated upstream `did/ic.did` source from `dfinity/portal` → `dfinity/developer-docs` (new authoritative location).
+- `REGENERATING.md`: documented `didc` ≥ 0.6.x build-from-source requirement and the `PascalCase` type-name conversion step.
+
 ## 4.0.0
 
-Types are now generated from the upstream Candid spec ([`did/ic.did`](./did/ic.did), mirrored from [`dfinity/portal`](https://github.com/dfinity/portal/blob/master/docs/references/_attachments/ic.did)) via `didc bind --target mo`. The generated module lives at `mo:ic/Types`; `mo:ic` itself stays a thin actor wrapper.
+Types are now generated from the upstream Candid spec ([`did/ic.did`](./did/ic.did), mirrored from [`dfinity/developer-docs`](https://github.com/dfinity/developer-docs/blob/main/public/references/ic.did)) via `didc bind --target mo`. The generated module lives at `mo:ic/Types`; `mo:ic` itself stays a thin actor wrapper.
 
 ### Migration
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![mops](https://oknww-riaaa-aaaam-qaf6a-cai.raw.ic0.app/badge/mops/ic)](https://mops.one/ic)
 [![documentation](https://oknww-riaaa-aaaam-qaf6a-cai.raw.ic0.app/badge/documentation/ic)](https://mops.one/ic/docs)
 
-Motoko interface for the IC management canister (`aaaaa-aa`). The Motoko types are generated from the upstream Candid spec mirrored at [`did/ic.did`](./did/ic.did) (from [`dfinity/portal`](https://github.com/dfinity/portal/blob/master/docs/references/_attachments/ic.did)).
+Motoko interface for the IC management canister (`aaaaa-aa`). The Motoko types are generated from the upstream Candid spec mirrored at [`did/ic.did`](./did/ic.did) (from [`dfinity/developer-docs`](https://github.com/dfinity/developer-docs/blob/main/public/references/ic.did)).
 
 See [Call](https://mops.one/ic/docs/Call) module documentation for automatic calculation of the minimum amount of cycles and attaching them to the call.
 

--- a/REGENERATING.md
+++ b/REGENERATING.md
@@ -2,14 +2,22 @@
 
 How to update `src/Types.mo` when `did/ic.did` changes upstream.
 
-Assumes `didc` supports `--target mo` with `Float32` (≥ 0.6.x).
+Requires `didc` ≥ 0.6.x for `Float32` support. As of 2026-06-11 the released binary is 0.5.4 (lacks `Float32`); build from source:
+
+```bash
+git clone --depth 1 https://github.com/dfinity/candid.git /tmp/candid-src
+cargo build --release --manifest-path /tmp/candid-src/Cargo.toml -p didc
+# binary at /tmp/candid-src/target/release/didc
+```
+
+**Note on naming:** `didc bind --target mo` outputs `snake_case` type names. The canonical `src/Types.mo` uses `PascalCase` for type names (field names and method names stay `snake_case`). The TL;DR and steps below include the conversion.
 
 ## TL;DR
 
 ```bash
 curl -fsSL -o did/ic.did \
-  https://raw.githubusercontent.com/dfinity/portal/master/docs/references/_attachments/ic.did
-didc bind --target mo did/ic.did > src/Types.mo
+  https://raw.githubusercontent.com/dfinity/developer-docs/refs/heads/main/public/references/ic.did
+didc bind --target mo did/ic.did | python3 scripts/pascal_types.py > src/Types.mo
 mops test                                    # builds + runs tests
 git diff src/Types.mo                        # classify the change (see step 4)
 ```
@@ -22,7 +30,7 @@ Then decide the semver bump (below), update `mops.toml` + `CHANGELOG.md`, commit
 
 ```bash
 curl -fsSL -o did/ic.did \
-  https://raw.githubusercontent.com/dfinity/portal/master/docs/references/_attachments/ic.did
+  https://raw.githubusercontent.com/dfinity/developer-docs/refs/heads/main/public/references/ic.did
 git diff did/ic.did
 ```
 
@@ -31,8 +39,10 @@ If the diff is empty, you're done.
 ### 2. Regenerate `src/Types.mo`
 
 ```bash
-didc bind --target mo did/ic.did > src/Types.mo
+didc bind --target mo did/ic.did | python3 scripts/pascal_types.py > src/Types.mo
 ```
+
+`scripts/pascal_types.py` converts `snake_case` type names to `PascalCase` (field names and method names are left as-is). See the script for details.
 
 ### 3. Type-check + tests
 

--- a/did/ic.did
+++ b/did/ic.did
@@ -630,6 +630,30 @@ type upload_canister_snapshot_data_args = record {
     chunk : blob;
 };
 
+type cycles_consumed = record {
+  memory : nat;
+  compute_allocation : nat;
+  ingress_induction : nat;
+  instructions : nat;
+  request_and_response_transmission : nat;
+  // This metric applies to canisters that ran out of cycles. In particular,
+  // uninstalling code explicitly would not result in this metric being updated.
+  // In fact, others might be updated in that case, e.g. cycles for ingress induction
+  // if the uninstallation of the canister was requested via an ingress message.
+  uninstall : nat;
+  canister_creation : nat;
+  http_outcalls : nat;
+  burned_cycles : nat;
+};
+
+type canister_metrics_args = record {
+  canister_id : canister_id;
+};
+
+type canister_metrics_result = record {
+  cycles_consumed : cycles_consumed;
+};
+
 service ic : {
     create_canister : (create_canister_args) -> (create_canister_result);
     update_settings : (update_settings_args) -> ();
@@ -642,6 +666,8 @@ service ic : {
     start_canister : (start_canister_args) -> ();
     stop_canister : (stop_canister_args) -> ();
     canister_status : (canister_status_args) -> (canister_status_result) query;
+    // Returns canister related metrics
+    canister_metrics: (canister_metrics_args) -> (canister_metrics_result) query;
     delete_canister : (delete_canister_args) -> ();
     deposit_cycles : (deposit_cycles_args) -> ();
     raw_rand : () -> (raw_rand_result);

--- a/mops.toml
+++ b/mops.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic"
-version = "4.0.0"
+version = "4.1.0"
 description = "IC management canister interface (aaaaa-aa)"
 repository = "https://github.com/caffeinelabs/mops-ic"
 keywords = ["ic", "types", "interface", "http"]

--- a/scripts/pascal_types.py
+++ b/scripts/pascal_types.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""
+Post-process `didc bind --target mo` output: convert snake_case type names to
+PascalCase.  Field names and method names stay snake_case; only type-definition
+names and their references as types are converted.
+
+Usage:
+    didc bind --target mo did/ic.did | python3 scripts/pascal_types.py > src/Types.mo
+"""
+import re
+import sys
+
+
+def snake_to_pascal(name: str) -> str:
+    return "".join(w.capitalize() for w in name.split("_"))
+
+
+def main() -> None:
+    content = sys.stdin.read()
+
+    # Collect every type name defined in the file.
+    type_names = set(re.findall(r"public type (\w+)\s*=", content))
+    mapping = {n: snake_to_pascal(n) for n in type_names if n != snake_to_pascal(n)}
+
+    # Apply conversion line-by-line.
+    # - Skip comment lines (leave them verbatim).
+    # - Replace type-name occurrences that are NOT immediately followed by ' :'
+    #   (the ' :' pattern marks a field name or method name, not a type reference).
+    sorted_pairs = sorted(mapping.items(), key=lambda x: -len(x[0]))
+    lines = []
+    for line in content.split("\n"):
+        if line.strip().startswith("//"):
+            lines.append(line)
+            continue
+        for snake, pascal in sorted_pairs:
+            line = re.sub(r"\b" + re.escape(snake) + r"\b(?!\s*:)", pascal, line)
+        lines.append(line)
+
+    result = "\n".join(lines)
+
+    # The comment on line 2 contains the literal string "ic:canister_id"; the
+    # replacement above turns it into "ic:CanisterId" — restore it.
+    result = result.replace("ic:CanisterId", "ic:canister_id")
+
+    sys.stdout.write(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/Types.mo
+++ b/src/Types.mo
@@ -68,6 +68,8 @@ module {
   };
   public type CanisterMetadataArgs = { name : Text; canister_id : CanisterId };
   public type CanisterMetadataResult = { value : Blob };
+  public type CanisterMetricsArgs = { canister_id : CanisterId };
+  public type CanisterMetricsResult = { cycles_consumed : CyclesConsumed };
   public type CanisterSettings = {
     freezing_threshold : ?Nat;
     wasm_memory_threshold : ?Nat;
@@ -154,6 +156,21 @@ module {
     sender_canister_version : ?Nat64;
   };
   public type CreateCanisterResult = { canister_id : CanisterId };
+  public type CyclesConsumed = {
+    memory : Nat;
+    canister_creation : Nat;
+    burned_cycles : Nat;
+    http_outcalls : Nat;
+    instructions : Nat;
+    /// This metric applies to canisters that ran out of cycles. In particular,
+    /// uninstalling code explicitly would not result in this metric being updated.
+    /// In fact, others might be updated in that case, e.g. cycles for ingress induction
+    /// if the uninstallation of the canister was requested via an ingress message.
+    uninstall : Nat;
+    ingress_induction : Nat;
+    request_and_response_transmission : Nat;
+    compute_allocation : Nat;
+  };
   public type DefiniteCanisterSettings = {
     freezing_threshold : Nat;
     wasm_memory_threshold : Nat;
@@ -413,6 +430,8 @@ module {
     /// Public canister data
     canister_info : shared CanisterInfoArgs -> async CanisterInfoResult;
     canister_metadata : shared CanisterMetadataArgs -> async CanisterMetadataResult;
+    /// Returns canister related metrics
+    canister_metrics : shared query CanisterMetricsArgs -> async CanisterMetricsResult;
     canister_status : shared query CanisterStatusArgs -> async CanisterStatusResult;
     clear_chunk_store : shared ClearChunkStoreArgs -> async ();
     create_canister : shared CreateCanisterArgs -> async CreateCanisterResult;


### PR DESCRIPTION
## Summary

- Fixes the upstream `ic.did` source URL across all docs (`dfinity/portal` → `dfinity/developer-docs`, the new authoritative location).
- Refreshes `did/ic.did` from the new upstream — adds `CyclesConsumed`, `CanisterMetricsArgs`, `CanisterMetricsResult` types and the `canister_metrics` query method.
- Bumps to **4.1.0** (additive-only change).
- Adds `scripts/pascal_types.py` and documents the `didc` build-from-source + PascalCase conversion steps in `REGENERATING.md` (see note below).

Closes #10.

## Changes

| File | What changed |
|---|---|
| `did/ic.did` | Refreshed from `dfinity/developer-docs` |
| `src/Types.mo` | +`CyclesConsumed`, `CanisterMetricsArgs`, `CanisterMetricsResult`; +`canister_metrics` on `Self` |
| `mops.toml` | Version bumped 4.0.0 → 4.1.0 |
| `CHANGELOG.md` | 4.1.0 entry + corrected `dfinity/portal` link in 4.0.0 entry |
| `README.md` | Updated `dfinity/portal` link |
| `REGENERATING.md` | Updated URLs; documented `didc` build-from-source and PascalCase conversion |
| `scripts/pascal_types.py` | New — post-processes `didc bind --target mo` output to PascalCase type names |

## Note on `didc` and PascalCase type names

`didc 0.5.4` (latest released binary) panics on `float32`, which `ic.did` already uses. `didc 0.6.1` on `main` fixes this but hasn't been released yet — `REGENERATING.md` now documents building from source.

`didc bind --target mo` outputs `snake_case` type names. The canonical `src/Types.mo` uses `PascalCase` (Motoko convention for types). This was silently handled by Cursor when generating the original file in #7 but never documented. The `scripts/pascal_types.py` script formalises that post-processing step.

The correct long-term fix is a small upstream change to `dfinity/candid`'s `motoko.rs` binding generator to emit PascalCase type names — the same way the Rust generator already emits PascalCase struct/enum names. Filed as [dfinity/candid#733](https://github.com/dfinity/candid/issues/733). Once that lands and a new binary is released, `pascal_types.py` can be dropped and `REGENERATING.md` simplified.

## Vetkey note

The comment on #10 mentions `vetkd_public_key`/`vetkd_derive_key` being absent from `mo:ic` as a motivating example. Those bindings have actually been present since **v3.0.0** — they were not affected by the stale upstream. The `mo:ic-vetkeys/ManagementCanister` shim remains necessary for now because it adds convenience wrappers and automatic cycle attachment on top of the raw IC methods; the underlying type/method gap is already closed.

Adding vetkey helpers to `mo:ic/Call.mo` (consistent with the existing ECDSA/Schnorr/HTTP pattern) would make the shim's `ManagementCanister.mo` wrapper redundant. Filed as #12.

## Test plan

- [x] `mops test` passes locally
- [ ] Reviewer confirms `canister_metrics` signature matches the upstream `.did`