### PR TITLE
docs: clarify publishing is automated on merge

### DIFF
--- a/REGENERATING.md
+++ b/REGENERATING.md
@@ -79,11 +79,10 @@ Standard flow. CI runs `mops test`.
 
 ### 7. Publish
 
-After merge:
-
-```bash
-mops publish
-```
+Publishing is automatic: merging the version bump to `master` triggers the
+`mops publish` workflow, which publishes to the registry and tags the release.
+Don't run `mops publish` by hand. To retry after a transient failure, re-run the
+workflow via `workflow_dispatch`.
 
 ## Notes
 


### PR DESCRIPTION
`REGENERATING.md` step 7 instructed maintainers to run `mops publish` by hand after merging a version bump. That's stale: the `mops publish` workflow already publishes and tags automatically whenever `mops.toml`'s version changes on `master`. A manual run is redundant and could race the CI publish.

Step 7 now documents the automatic flow and points to `workflow_dispatch` for retries.

Made with [Cursor](https://cursor.com)