### PR TITLE
feat: add #patch to http_request method (4.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 4.2.0
+
+### Additive changes
+
+- `HttpRequestArgs.method` gains the `#patch` case. The IC interface spec added `patch` to `http_request` (dfinity/developer-docs#289, merged 2026-06-29); `PATCH` HTTPS outcalls are rolled out across all subnets. Additive variant-case change — existing `#get`/`#head`/`#post`/`#put`/`#delete` callers are unaffected.
+
+### Housekeeping
+
+- Refreshed `did/ic.did` from `dfinity/developer-docs` main (only the `http_request_args.method` variant changed).
+
 ## 4.1.0
 
 ### Additive changes

--- a/did/ic.did
+++ b/did/ic.did
@@ -344,7 +344,7 @@ type deposit_cycles_args = record {
 type http_request_args = record {
     url : text;
     max_response_bytes : opt nat64;
-    method : variant { get; head; post; put; delete };
+    method : variant { get; head; post; put; delete; patch };
     headers : vec http_header;
     body : opt blob;
     transform : opt record {

--- a/mops.toml
+++ b/mops.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic"
-version = "4.1.0"
+version = "4.2.0"
 description = "IC management canister interface (aaaaa-aa)"
 repository = "https://github.com/caffeinelabs/mops-ic"
 keywords = ["ic", "types", "interface", "http"]

--- a/src/Types.mo
+++ b/src/Types.mo
@@ -204,7 +204,7 @@ module {
   public type HttpHeader = { value : Text; name : Text };
   public type HttpRequestArgs = {
     url : Text;
-    method : { #get; #put; #head; #post; #delete };
+    method : { #get; #put; #head; #post; #delete; #patch };
     max_response_bytes : ?Nat64;
     body : ?Blob;
     transform : ?{


### PR DESCRIPTION
## What

Adds the `#patch` case to `HttpRequestArgs.method` in `src/Types.mo`, bumps the package to **4.2.0**, and refreshes `did/ic.did`.

## Why

The IC interface spec added `patch` to the management-canister `http_request` method — [dfinity/developer-docs#289](https://github.com/dfinity/developer-docs/pull/289), merged 2026-06-29. PATCH HTTPS outcalls are rolled out across all subnets, so the `ic` package should expose it.

## How

Followed `REGENERATING.md`:
- `did/ic.did` refreshed from `dfinity/developer-docs` main — the only change is `http_request_args.method` gaining `patch`.
- `src/Types.mo` regenerated via `didc 0.6.2 bind --target mo | pascal_types.py`. The sole semantic diff is the new `#patch` variant case; incidental record-wrapping churn from the newer didc formatter was discarded to keep the diff to the established format (CI runs `mops test` only — no format gate).
- Minor bump per the `REGENERATING.md` semver table (new input variant case = minor): **4.1.0 → 4.2.0**.
- CHANGELOG updated.

## Compatibility

Additive variant-case addition — existing `#get`/`#head`/`#post`/`#put`/`#delete` callers are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)